### PR TITLE
Add Base View Model

### DIFF
--- a/app/src/main/java/com/qudus/tudee/ui/base/BaseViewModel.kt
+++ b/app/src/main/java/com/qudus/tudee/ui/base/BaseViewModel.kt
@@ -1,0 +1,51 @@
+package com.qudus.tudee.ui.base
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.qudus.tudee.domain.exception.TudeeExecption
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+open class BaseViewModel<STATE>(initialState: STATE): ViewModel() {
+
+    protected val _state: MutableStateFlow<STATE> by lazy { MutableStateFlow(initialState) }
+    val state = _state.asStateFlow()
+
+    protected fun <T> tryToExecute(
+        action: suspend () -> T,
+        onSuccess: (T) -> Unit,
+        onError: (TudeeExecption) -> Unit,
+        completion: () -> Unit = {},
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) {
+        viewModelScope.launch(dispatcher) {
+            try {
+                onSuccess(action())
+            } catch (exception: TudeeExecption) {
+                onError(exception)
+            } finally {
+                completion()
+            }
+        }
+    }
+
+    protected fun <T> collectFlow(
+        flow: Flow<T>,
+        onEach: (T) -> Unit,
+        onError: (TudeeExecption) -> Unit = {},
+        dispatcher: CoroutineDispatcher = Dispatchers.IO
+    ) {
+        viewModelScope.launch(dispatcher) {
+            try {
+                flow.collect { value -> onEach(value) }
+            } catch (e: TudeeExecption) {
+                onError(e)
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR introduces two coroutine helper functions in `BaseViewModel `to reduce boilerplate when interacting with Use Cases. It includes:

✅ ### New in BaseViewModel:
**`tryToExecute(...) `**
A utility for executing **suspend** functions with **success** and **error** callbacks.

`**collectFlow(...)** `
A wrapper for **collecting** flows inside viewModelScope.

 ✅ ### Example Usage: CategoryViewModel
```
class CategoryViewModel(
    private val getCategories: GetCategoriesUseCase
) : BaseViewModel<CategoryUiState>(CategoryUiState()) {
    
    **//*************************  How To Use collectFlow  *************************** 
    
    fun fetchCategories() {
        collectFlow<Category>(
            flow =  getCategories.getCategories() ,
            onEach = ::onGetEachCategory,
            onError = ::onGetCategoriesError,
        )
    }
    
    private fun onGetEachCategory(category: Category){
        //todo: update my state 
    }

    private fun onGetCategoriesError(exception: TudeeExecption){
        //todo: update my error state value
    }

    **//*************************  How To Use tryToExecute  *************************** 
    
    fun fetchCategory(){
        tryToExecute(
            action = getCategories::getCategory,
            onSuccess = ::onGetCategorySuccess,
            onError = ::onGetCategoryError,
        )
    }

    private fun onGetCategorySuccess(category: Category){
        //todo: update my state
    }

    private fun onGetCategoryError(exception: TudeeExecption){
        //todo: update my error state value
    }

}
```