### PR TITLE
Add Tudee Bottom Sheet

### DIFF
--- a/app/src/main/java/com/qudus/tudee/ui/designSystem/component/TudeeBottomSheet.kt
+++ b/app/src/main/java/com/qudus/tudee/ui/designSystem/component/TudeeBottomSheet.kt
@@ -1,0 +1,50 @@
+package com.qudus.tudee.ui.designSystem.component
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.BottomSheetDefaults.DragHandle
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.qudus.tudee.ui.designSystem.theme.Theme
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TudeeBottomSheet(
+    isSheetOpen: Boolean,
+    onDismissRequest: () -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    AnimatedVisibility(
+        visible = isSheetOpen,
+        enter = slideInVertically(),
+        exit = slideOutVertically()
+    ) {
+        ModalBottomSheet(
+            modifier = modifier.fillMaxWidth(),
+            onDismissRequest = onDismissRequest,
+            containerColor = Theme.color.surface,
+            dragHandle = { TudeeDragHandle() }
+        ) {
+            content()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun TudeeDragHandle() {
+    DragHandle(
+        width = 32.dp,
+        height = 4.dp,
+        color = Theme.color.body,
+        shape = CircleShape
+    )
+}

--- a/app/src/main/java/com/qudus/tudee/ui/designSystem/component/TudeeBottomSheet.kt
+++ b/app/src/main/java/com/qudus/tudee/ui/designSystem/component/TudeeBottomSheet.kt
@@ -4,11 +4,19 @@ import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.systemBarsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.BottomSheetDefaults.DragHandle
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -20,15 +28,22 @@ fun TudeeBottomSheet(
     isSheetOpen: Boolean,
     onDismissRequest: () -> Unit,
     modifier: Modifier = Modifier,
+    expanded: Boolean = true,
     content: @Composable ColumnScope.() -> Unit
 ) {
+    val sheetState =
+        rememberModalBottomSheetState(
+            skipPartiallyExpanded = expanded,
+        )
+
     AnimatedVisibility(
         visible = isSheetOpen,
         enter = slideInVertically(),
         exit = slideOutVertically()
     ) {
         ModalBottomSheet(
-            modifier = modifier.fillMaxWidth(),
+            modifier = modifier.fillMaxWidth().navigationBarsPadding(),
+            sheetState = sheetState,
             onDismissRequest = onDismissRequest,
             containerColor = Theme.color.surface,
             dragHandle = { TudeeDragHandle() }


### PR DESCRIPTION
This PR introduces a reusable TudeeBottomSheet composable to the Tudee design system. It encapsulates the Material3 ModalBottomSheet with built-in animation and styling to maintain consistency across the app.

### ✨ Features

- Adds TudeeBottomSheet, a wrapper around ModalBottomSheet with:
- Slide in/out vertical animation using AnimatedVisibility
- Custom container color from Theme.color.surface
- A stylized TudeeDragHandle for consistent UI

### 💡 Usage
```
TudeeBottomSheet(
    isSheetOpen = state.isVisible,
    onDismissRequest = { state.hide() }
) {
    // Bottom sheet content here
}
```