### PR TITLE
Refactor TaskDetailsScreen and ViewModel

### DIFF
--- a/app/src/main/java/com/qudus/tudee/ui/designSystem/component/TudeeBottomSheet.kt
+++ b/app/src/main/java/com/qudus/tudee/ui/designSystem/component/TudeeBottomSheet.kt
@@ -30,7 +30,6 @@ fun TudeeBottomSheet(
     val sheetState =
         rememberModalBottomSheetState(
             skipPartiallyExpanded = expanded,
-            confirmValueChange  = { it != SheetValue.Hidden }
         )
 
     AnimatedVisibility(

--- a/app/src/main/java/com/qudus/tudee/ui/screen/task_details/TaskDetailsRoute.kt
+++ b/app/src/main/java/com/qudus/tudee/ui/screen/task_details/TaskDetailsRoute.kt
@@ -21,7 +21,7 @@ fun NavGraphBuilder.taskDetailsRoute(navController: NavController) {
             navArgument(name = TaskDetailsArgs.TASK_ID_ARG) { NavType.LongType }
         ),
     ) {
-        TaskDetailsScreen(navController)
+//        TaskDetailsScreen(navController = navController, taskId = 0, onDismiss = {}, onEditTaskClick = {})
     }
 }
 

--- a/app/src/main/java/com/qudus/tudee/ui/screen/task_details/TaskDetailsViewModel.kt
+++ b/app/src/main/java/com/qudus/tudee/ui/screen/task_details/TaskDetailsViewModel.kt
@@ -17,10 +17,9 @@ import org.koin.core.component.KoinComponent
 class TaskDetailsViewModel(
     private val taskService: TaskService,
     private val categoryService: CategoryService,
+    private val taskId: Long,
+    private val onDismiss: () -> Unit,
 ) : BaseViewModel<TaskDetailsUiState>(TaskDetailsUiState()), KoinComponent {
-
-    //todo: receive task id that i need to get Task
-    val taskId: Long = 3
 
     init {
         fetchTaskDetails()
@@ -60,14 +59,6 @@ class TaskDetailsViewModel(
         _state.update { it.copy(exception = exception) }
     }
 
-    fun onDismiss() {
-        _state.update { it.copy(isVisible = false) }
-    }
-
-    fun onEditTaskClick() {
-        // TODO: navigate to edit task
-    }
-
     fun onMoveTaskStatusClick() {
         setLoadingState(true)
         tryToExecute(
@@ -99,6 +90,9 @@ class TaskDetailsViewModel(
                 )
             )
         }
+        if (nextState == TaskStatusUiState.DONE) {
+            onDismiss()
+        }
         updateTaskCompletionStatus()
     }
 
@@ -113,7 +107,6 @@ class TaskDetailsViewModel(
     private fun onMoveStateError(exception: TudeeExecption) {
         setLoadingState(false)
         _state.update { it.copy(exception = exception) }
-        // TODO: dismiss and send exception
         onDismiss()
     }
 }


### PR DESCRIPTION
- Remove NavController dependency from TaskDetailsScreen and pass required parameters directly.
- Modify TaskDetailsViewModel to accept `taskId` and `onDismiss` callback as constructor parameters.
- Update `onMoveTaskStatusClick` to dismiss the bottom sheet if the task is moved to "DONE".
- Adjust `TudeeBottomSheet` to remove `confirmValueChange` logic.